### PR TITLE
Changed UnitOfWork from Transcient to Scoped in Startup

### DIFF
--- a/aspnet/RVTR.Lodging.Context/Repositories/UnitOfWork.cs
+++ b/aspnet/RVTR.Lodging.Context/Repositories/UnitOfWork.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using RVTR.Lodging.Domain.Interfaces;
 using RVTR.Lodging.Domain.Models;
@@ -8,7 +7,7 @@ namespace RVTR.Lodging.Context.Repositories
   /// <summary>
   /// Represents the _UnitOfWork_ repository
   /// </summary>
-  public class UnitOfWork : IUnitOfWork, IDisposable
+  public class UnitOfWork : IUnitOfWork
   {
     private readonly LodgingContext _context;
     private bool _disposedValue;
@@ -33,22 +32,5 @@ namespace RVTR.Lodging.Context.Repositories
     /// </summary>
     /// <returns></returns>
     public async Task<int> CommitAsync() => await _context.SaveChangesAsync();
-
-    protected virtual void Dispose(bool disposing)
-    {
-      if (!_disposedValue)
-      {
-        if (disposing)
-        {
-          _context.Dispose();
-        }
-        _disposedValue = true;
-      }
-    }
-    public void Dispose()
-    {
-      Dispose(disposing: true);
-      GC.SuppressFinalize(this);
-    }
   }
 }

--- a/aspnet/RVTR.Lodging.Service/Startup.cs
+++ b/aspnet/RVTR.Lodging.Service/Startup.cs
@@ -67,7 +67,7 @@ namespace RVTR.Lodging.Service
       }, ServiceLifetime.Transient);
 
       services.AddScoped<ClientZipkinMiddleware>();
-      services.AddTransient<IUnitOfWork, UnitOfWork>();
+      services.AddScoped<IUnitOfWork, UnitOfWork>();
       services.AddSwaggerGen();
       services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ClientSwaggerOptions>();
       services.AddVersionedApiExplorer(options =>


### PR DESCRIPTION
Change the UnitOfWork in Startup from Transcient to Scoped.
Closes issue #74 